### PR TITLE
Add JWT service unit test

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "api.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node test/jwt.test.js"
   },
   "repository": {
     "type": "git",

--- a/test/jwt.test.js
+++ b/test/jwt.test.js
@@ -1,0 +1,12 @@
+const assert = require('assert');
+const jwtService = require('../services/jwt');
+
+const secret = 'testsecret';
+const payload = { userId: 123, role: 'tester' };
+
+const token = jwtService.encode(payload, secret);
+const decoded = jwtService.decode('Bearer ' + token, secret);
+
+assert.deepStrictEqual(decoded, payload, 'Decoded payload should match the original');
+
+console.log('JWT encode/decode test passed.');


### PR DESCRIPTION
## Summary
- add unit test for JWT encode/decode
- run test with `node` via npm

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683f4094f61c832cac6448703c51a29d